### PR TITLE
Update sumup.dart

### DIFF
--- a/lib/sumup.dart
+++ b/lib/sumup.dart
@@ -158,7 +158,7 @@ class Sumup {
     final request = paymentRequest.toMap();
     final method = await _channel.invokeMethod('checkout', request);
     final response = SumupPluginResponse.fromMap(method);
-    return SumupPluginCheckoutResponse.fromMap(response.message!);
+    return SumupPluginCheckoutResponse.fromMap(response.message! as Map<String, dynamic>);
   }
 
   /// Only available for iOS, on Android always returns false.


### PR DESCRIPTION
Cast response.message to Map<String, dynamic> in checkout() to fix a Dart type error (Map<dynamic, dynamic> can’t be assigned to Map<String, dynamic>).

This ensures compatibility with strict type checking and prevents runtime errors.