### PR TITLE
Fix Android Tap-to-Pay affiliateKey and foreign_transaction_id mapping

### DIFF
--- a/android/src/main/kotlin/io/purplesoft/sumup/SumupPlugin.kt
+++ b/android/src/main/kotlin/io/purplesoft/sumup/SumupPlugin.kt
@@ -231,6 +231,7 @@ class SumupPlugin : FlutterPlugin, MethodCallHandler, ActivityAware, PluginRegis
                 applicationContext = activity.applicationContext,
                 payment = payment,
                 accessToken = ttpAccessToken,
+                affiliateKey = affiliateKey,
                 onResult = { responseMap ->
                     result.success(
                         mapOf(

--- a/android/src/main/kotlin/io/purplesoft/sumup/TapToPayRunner.kt
+++ b/android/src/main/kotlin/io/purplesoft/sumup/TapToPayRunner.kt
@@ -6,6 +6,7 @@ import android.util.Log
 import com.sumup.taptopay.TapToPay
 import com.sumup.taptopay.TapToPayApiProvider
 import com.sumup.taptopay.auth.AuthTokenProvider
+import com.sumup.taptopay.payment.domain.model.api.AffiliateModel
 import com.sumup.taptopay.payment.domain.model.api.CheckoutData
 import com.sumup.taptopay.payment.domain.model.api.PaymentEvent
 import kotlinx.coroutines.flow.catch
@@ -111,6 +112,7 @@ internal object TapToPayRunner {
         applicationContext: Context,
         payment: Map<String, Any?>,
         accessToken: String?,
+        affiliateKey: String?,
         onResult: (Map<String, Any?>) -> Unit
     ) {
         if (accessToken.isNullOrBlank()) {
@@ -150,10 +152,20 @@ internal object TapToPayRunner {
             val tip = (payment["tip"] as? Number)?.toDouble() ?: 0.0
             val totalMinor = (total * 100).toLong()
             val tipsMinor = if (tip > 0) (tip * 100).toLong() else null
-            val clientTxId = (payment["foreignTransactionId"] as? String)
+            val requestedForeignTransactionId = (payment["foreignTransactionId"] as? String)
                 ?.takeIf { it.isNotBlank() }
+            val clientTxId = requestedForeignTransactionId
                 ?: UUID.randomUUID().toString()
             val skipSuccessScreen = payment["skipSuccessScreen"] == true
+            val affiliateData = affiliateKey
+                ?.takeIf { it.isNotBlank() }
+                ?.let { key ->
+                    AffiliateModel(
+                        key,
+                        requestedForeignTransactionId,
+                        null
+                    )
+                }
             val checkoutData = CheckoutData(
                 totalAmount = totalMinor,
                 tipsAmount = tipsMinor,
@@ -163,7 +175,7 @@ internal object TapToPayRunner {
                 priceItems = null,
                 products = null,
                 processCardAs = null,
-                affiliateData = null
+                affiliateData = affiliateData
             )
             // resultSent guards against duplicate onResult calls:
             // TransactionDone fires first; PaymentFlowClosedSuccessfully fires after the


### PR DESCRIPTION
## Problem

Android Tap-to-Pay checkouts currently do not populate SumUp's `foreign_transaction_id` consistently with the card reader flow.

This makes backend reconciliation inconsistent when integrators query:

`transactions.get(merchantCode, { foreign_transaction_id: externalId })`

Card reader transactions are found, while Android TTP transactions are not.

## Root cause

In the Android TTP flow, the plugin currently maps the Flutter `foreignTransactionId` only to `CheckoutData.clientUniqueTransactionId`.

However, in the TTP SDK the actual affiliate metadata is carried through `AffiliateModel`, and `foreignTransactionId` should be provided there as well.

At the moment `affiliateData` is always `null`, so `foreign_transaction_id` is not propagated to SumUp as expected.

## Fix

- pass `affiliateKey` into the Android TTP checkout runner
- create `AffiliateModel(affiliateKey, foreignTransactionId, null)`
- set it on `CheckoutData.affiliateData`

This keeps the public Flutter API unchanged and only fixes the Android TTP native mapping.

## Verification

- `fvm flutter analyze` passes
- tested against a local integration scenario where card reader and Android TTP should both be retrievable through `foreign_transaction_id`
