### PR TITLE
feat(android): make Tap-to-Pay (utopia-sdk) optional

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -14,6 +14,14 @@ buildscript {
     }
 }
 
+// Tap-to-Pay (utopia-sdk) is hosted on a private SumUp Maven repo that requires partner
+// credentials. When SUMUP_TTP_MAVEN_USERNAME is provided (gradle.properties / -P / env),
+// the real Tap-to-Pay implementation (src/ttp) + the utopia-sdk dependency are compiled in.
+// Otherwise the no-op stub (src/nottp) is used and the private repo is never contacted, so
+// the plugin builds anywhere. The card-reader (merchant-sdk) path works in both modes.
+def ttpUser = (rootProject.findProperty('SUMUP_TTP_MAVEN_USERNAME') ?: '').toString().trim()
+def ttpEnabled = !ttpUser.isEmpty()
+
 rootProject.allprojects {
     repositories {
         google()
@@ -25,15 +33,17 @@ rootProject.allprojects {
                 includeGroup 'net.sf.smc'
             }
         }
-        maven {
-            url = uri('https://tap-to-pay-sdk.fleet.live.sumup.net/')
-            content {
-                includeGroupByRegex 'com\\.sumup.*'
-                includeGroup 'ca.amadis.agnos'
-            }
-            credentials {
-                username = rootProject.findProperty('SUMUP_TTP_MAVEN_USERNAME')?.toString() ?: ''
-                password = rootProject.findProperty('SUMUP_TTP_MAVEN_PASSWORD')?.toString() ?: ''
+        if (ttpEnabled) {
+            maven {
+                url = uri('https://tap-to-pay-sdk.fleet.live.sumup.net/')
+                content {
+                    includeGroup 'com.sumup.tap-to-pay'
+                    includeGroup 'ca.amadis.agnos'
+                }
+                credentials {
+                    username = rootProject.findProperty('SUMUP_TTP_MAVEN_USERNAME')?.toString() ?: ''
+                    password = rootProject.findProperty('SUMUP_TTP_MAVEN_PASSWORD')?.toString() ?: ''
+                }
             }
         }
     }
@@ -64,6 +74,8 @@ android {
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
+        // Compile either the real Tap-to-Pay runner (needs utopia-sdk) or the no-op stub.
+        main.java.srcDirs += (ttpEnabled ? 'src/ttp/kotlin' : 'src/nottp/kotlin')
     }
 
     lint {
@@ -76,5 +88,8 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3"
     implementation "com.google.android.gms:play-services-location:21.3.0"
     api 'com.sumup:merchant-sdk:6.0.0'
-    implementation 'com.sumup.tap-to-pay:utopia-sdk:1.0.6'
+    // Tap-to-Pay SDK: only when partner Maven credentials are supplied (see note above).
+    if (ttpEnabled) {
+        implementation 'com.sumup.tap-to-pay:utopia-sdk:1.0.6'
+    }
 }

--- a/android/src/nottp/kotlin/io/purplesoft/sumup/TapToPayRunner.kt
+++ b/android/src/nottp/kotlin/io/purplesoft/sumup/TapToPayRunner.kt
@@ -1,0 +1,46 @@
+package io.purplesoft.sumup
+
+import android.content.Context
+
+/**
+ * No-op Tap-to-Pay implementation, compiled when the build is configured WITHOUT the
+ * SumUp Tap-to-Pay SDK (utopia-sdk). Selected by android/build.gradle when the
+ * SUMUP_TTP_MAVEN_USERNAME Gradle property is not provided.
+ *
+ * It mirrors the public API surface of the real `ttp` source-set TapToPayRunner so that
+ * SumupPlugin.kt compiles unchanged. Every entry point reports that Tap-to-Pay is not
+ * available in this build. The card-reader (merchant-sdk) checkout path is unaffected.
+ *
+ * To enable Tap-to-Pay, supply the SumUp Tap-to-Pay Maven credentials
+ * (SUMUP_TTP_MAVEN_USERNAME / SUMUP_TTP_MAVEN_PASSWORD) and rebuild — the real
+ * implementation in src/ttp is then compiled instead. See ANDROID_TTP.md.
+ */
+internal object TapToPayRunner {
+
+    private const val UNAVAILABLE =
+        "Tap-to-Pay is not included in this build (compiled without utopia-sdk). " +
+        "Rebuild with the SumUp Tap-to-Pay Maven credentials to enable it."
+
+    /** Returns Triple(isAvailable, isActivated, errorMessage). */
+    @Suppress("UNUSED_PARAMETER")
+    fun checkAvailability(
+        applicationContext: Context,
+        accessToken: String?
+    ): Triple<Boolean, Boolean, String?> = Triple(false, false, UNAVAILABLE)
+
+    @Suppress("UNUSED_PARAMETER")
+    suspend fun runCheckout(
+        applicationContext: Context,
+        payment: Map<String, Any?>,
+        accessToken: String?,
+        affiliateKey: String?,
+        onResult: (Map<String, Any?>) -> Unit
+    ) {
+        onResult(mapOf("success" to false, "errors" to UNAVAILABLE))
+    }
+
+    @Suppress("UNUSED_PARAMETER")
+    suspend fun tearDown(applicationContext: Context) {
+        // no-op: nothing to tear down when Tap-to-Pay is not compiled in
+    }
+}

--- a/android/src/ttp/kotlin/io/purplesoft/sumup/TapToPayRunner.kt
+++ b/android/src/ttp/kotlin/io/purplesoft/sumup/TapToPayRunner.kt
@@ -17,6 +17,12 @@ import java.util.UUID
 /**
  * Runs Tap-to-Pay SDK flows (utopia-sdk dependency required).
  * See ANDROID_TTP.md.
+ *
+ * This file lives in the `ttp` source set and is compiled ONLY when the build is
+ * configured with the SumUp Tap-to-Pay Maven credentials (SUMUP_TTP_MAVEN_USERNAME).
+ * When those credentials are absent, the no-op stub in `src/nottp` is compiled instead,
+ * so the plugin (and any consuming app) builds without access to the private utopia-sdk
+ * Maven repository. See android/build.gradle.
  */
 internal object TapToPayRunner {
 


### PR DESCRIPTION
## Problem
`com.sumup.tap-to-pay:utopia-sdk` is hosted on a **private** SumUp Maven repo (`tap-to-pay-sdk.fleet.live.sumup.net`) that requires partner credentials. It was an **unconditional** dependency, so any consuming app or CI without those credentials failed the build with `401 Unauthorized` on `utopia-sdk-1.0.6.pom`.

The card-reader (merchant-sdk) path needs none of this, and Tap-to-Pay can't run on emulators/most CI anyway — yet the build was blocked for everyone.

## Fix
Tap-to-Pay is now **opt-in**, keyed on the `SUMUP_TTP_MAVEN_USERNAME` Gradle property:

| Credentials | Source set compiled | utopia-sdk dependency | Private repo |
|---|---|---|---|
| present | `src/ttp` (real `TapToPayRunner`) | added | registered |
| absent  | `src/nottp` (no-op stub)          | omitted | never contacted |

`SumupPlugin.kt` is untouched — both source sets expose the same `TapToPayRunner` API (`checkAvailability`, `runCheckout`, `tearDown`). The no-op stub returns a clear "not included in this build" message. To enable Tap-to-Pay, supply `SUMUP_TTP_MAVEN_USERNAME` / `SUMUP_TTP_MAVEN_PASSWORD` and rebuild.

## Verification
- Built a consuming Flutter app on an Android emulator **without** credentials → green (previously 401).
- Card-reader (merchant-sdk) path unaffected in both modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
