### PR TITLE
fix(android): declare Compose BOM explicitly (0.14.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 0.14.3
+
+* Android: declare the Compose BOM (`androidx.compose:compose-bom:2023.06.01`) explicitly (#78). The
+  SumUp `merchant-sdk:6.0.0` → `txresult:6.0.0` transitive dependency references Compose artifacts
+  (`material`, `material3`, `material3-window-size-class`, `ui-tooling-preview`) WITHOUT versions,
+  expecting that BOM; some consumer Gradle setups didn't apply the transitive BOM and failed with
+  `Could not find androidx.compose...:.` on `:sumup:debugCompileClasspath`. The BOM is now pinned to
+  the exact version merchant-sdk targets and exposed via `api` so both the plugin and consumers get
+  consistent Compose version constraints.
+
 ## 0.14.2
 
 * Android: make Tap-to-Pay (`utopia-sdk`) optional, keyed on the `SUMUP_TTP_MAVEN_USERNAME` Gradle property (#74). When the property is absent, the plugin compiles a no-op `TapToPayRunner` stub (`src/nottp`) and never contacts the private SumUp Tap-to-Pay Maven repo, so consuming apps and CI build without partner credentials (previously a hard `401` on `utopia-sdk`). When the property is present, the real implementation (`src/ttp`) and the `utopia-sdk` dependency are compiled in. The card-reader (merchant-sdk) checkout path is unchanged in both modes.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -87,6 +87,12 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3"
     implementation "com.google.android.gms:play-services-location:21.3.0"
+    // merchant-sdk's transitive com.sumup:txresult declares Compose deps (material, material3,
+    // ui-tooling-preview) WITHOUT versions, expecting the Compose BOM it references. Some consumer
+    // Gradle setups don't apply that transitive BOM, leaving them unresolved ("Could not find
+    // androidx.compose...:."). Declare the BOM explicitly (exact version from txresult's POM) and
+    // expose it via `api` so both this module and consumers get the version constraints.
+    api platform('androidx.compose:compose-bom:2023.06.01')
     api 'com.sumup:merchant-sdk:6.0.0'
     // Tap-to-Pay SDK: only when partner Maven credentials are supplied (see note above).
     if (ttpEnabled) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: sumup
 description: Flutter wrapper to use the SumUp SDK. With this plugin, your app can easily connect to a SumUp terminal, login and accept card payments on Android and iOS.
-version: 0.14.2
+version: 0.14.3
 repository: https://github.com/PurpleSoftSrl/sumup_flutter_plugin
 homepage: https://purplesoft.io
 


### PR DESCRIPTION
Fixes #78 — merchant-sdk's transitive txresult declares version-less Compose deps expecting compose-bom:2023.06.01; some Gradle setups don't apply the transitive BOM. Pin it explicitly via api. Verified: consuming app (purple_sales_pos) assembleDebug green.